### PR TITLE
Add missing #include <limits>

### DIFF
--- a/src/libANGLE/HandleAllocator.cpp
+++ b/src/libANGLE/HandleAllocator.cpp
@@ -10,6 +10,7 @@
 #include "libANGLE/HandleAllocator.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "common/debug.h"
 


### PR DESCRIPTION
This fixes compilation with more recent versions of libstdc++.