### PR TITLE
Add a GitHub Action to run tests on Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+name: ci
+on:
+  push:
+  #  branches: [ master ]
+  pull_request:
+    branches: [ master ]
+defaults:
+  run:
+    shell: bash  # Not pwsh on Windows to properly set the path
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 9  # Three versions of Node.js on three different OSes
+      matrix:  # Running 9 long-running tests uses a lot of resources!
+        node-version: [16.x, 18.x, 20.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:  # TODO: Remove the excludes and get the tests to pass
+          # Windows FAILS on all three versions of Node.js.
+          - os: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/setup-python@v4
+        with:  # This sets both python and python3 to the same version
+          python-version: 3.x
+      - run: python3 --version && python --version
+      - if: runner.os == 'Linux'
+        run: sudo apt-get install -y build-essential libglew-dev libglu1-mesa-dev libpci-dev libxi-dev pkg-config
+      # - run: npm ci || true
+      # - run: npm install || true
+      # - run: npm run build --if-present || true
+      # - run: npm test || true
+      - run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      - run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+      - run: gclient --version  # Does not actually show the version!
+      - run: git clone https://chromium.googlesource.com/angle/angle
+      - run: PATH="$(pwd)/depot_tools:$PATH" python3 scripts/bootstrap.py
+      - run: git clone https://github.com/nodejs/node-gyp  # Google's gyp runs legacy Python2
+      - run: gclient sync  # Windows fail because it seems to be running legacy Python2

--- a/build/gyp_angle
+++ b/build/gyp_angle
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Copyright (c) 2010 The ANGLE Project Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -13,7 +13,8 @@ import sys
 script_dir = os.path.dirname(__file__)
 angle_dir = os.path.normpath(os.path.join(script_dir, os.pardir))
 
-sys.path.insert(0, os.path.join(angle_dir, 'third_party', 'gyp', 'pylib'))
+# sys.path.insert(0, os.path.join(angle_dir, 'third_party', 'gyp', 'pylib'))  # Legacy Python
+sys.path.insert(0, os.path.join(angle_dir, 'node-gyp', 'gyp', 'pylib'))  # Modern Python
 import gyp
 
 def appendCommonArgs(args):
@@ -61,13 +62,13 @@ def generateWinRTProjects(generate_args, generation_dir, build_winphone, msvs_ve
     # Add all.gyp as the main gyp file to be generated.
     args.append(os.path.join(script_dir, 'ANGLE.gyp'))
 
-    print 'Generating WinRT projects to ' + generation_dir + ' from gyp files...'
+    print('Generating WinRT projects to ' + generation_dir + ' from gyp files...')
     sys.stdout.flush()
 
     gyp.main(args)
 
 if __name__ == '__main__':
-    print 'Updating projects from gyp files...'
+    print('Updating projects from gyp files...')
     sys.stdout.flush()
 
     # Generate projects

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -17,11 +17,15 @@ def main():
   try:
     rc = subprocess.call(gclient_cmd, shell=True)
   except OSError:
-    print 'could not run "%s" via shell' % gclient_cmd
+    print('could not run "%s" via shell' % gclient_cmd)
+    sys.exit(1)
+  except Exception as e:
+    print(repr(e))
+    print('could not run "%s" via shell' % gclient_cmd)
     sys.exit(1)
 
   if rc:
-    print 'failed command: "%s"' % gclient_cmd
+    print('failed command: "%s"' % gclient_cmd)
     sys.exit(1)
 
   with open('.gclient') as gclient_file:
@@ -30,7 +34,7 @@ def main():
   with open('.gclient', 'w') as gclient_file:
     gclient_file.write(content.replace('change2dot', '.'))
 
-  print 'created .gclient'
+  print('created .gclient')
 
 if __name__ == '__main__':
   main()

--- a/src/angle.gyp
+++ b/src/angle.gyp
@@ -21,7 +21,7 @@
         'angle_id_script': '<(angle_gen_path)/<(angle_id_script_base)',
         'angle_id_header_base': 'commit.h',
         'angle_id_header': '<(angle_gen_path)/id/<(angle_id_header_base)',
-        'angle_use_commit_id%': '<!(python <(angle_id_script_base) check ..)',
+        'angle_use_commit_id%': '<!(python3 <(angle_id_script_base) check ..)',
         'angle_enable_d3d9%': 0,
         'angle_enable_d3d11%': 0,
         'angle_enable_gl%': 0,
@@ -153,7 +153,7 @@
                             'msvs_cygwin_shell': 0,
                             'action':
                             [
-                                'python', '<(angle_id_script)', 'gen', '<(angle_path)', '<(angle_id_header)'
+                                'python3', '<(angle_id_script)', 'gen', '<(angle_path)', '<(angle_id_header)'
                             ],
                         },
                     ],
@@ -260,9 +260,9 @@
                             'action_name': 'ANGLE Post-Build Script',
                             'message': 'Running <(angle_post_build_script)...',
                             'msvs_cygwin_shell': 0,
-                            'inputs': [ '<(angle_post_build_script)', '<!@(["python", "<(angle_post_build_script)", "inputs", "<(angle_path)", "<(CONFIGURATION_NAME)", "$(PlatformName)", "<(PRODUCT_DIR)"])' ],
-                            'outputs': [ '<!@(python <(angle_post_build_script) outputs "<(angle_path)" "<(CONFIGURATION_NAME)" "$(PlatformName)" "<(PRODUCT_DIR)")' ],
-                            'action': ['python', '<(angle_post_build_script)', 'run', '<(angle_path)', '<(CONFIGURATION_NAME)', '$(PlatformName)', '<(PRODUCT_DIR)'],
+                            'inputs': [ '<(angle_post_build_script)', '<!@(["python3", "<(angle_post_build_script)", "inputs", "<(angle_path)", "<(CONFIGURATION_NAME)", "$(PlatformName)", "<(PRODUCT_DIR)"])' ],
+                            'outputs': [ '<!@(python3 <(angle_post_build_script) outputs "<(angle_path)" "<(CONFIGURATION_NAME)" "$(PlatformName)" "<(PRODUCT_DIR)")' ],
+                            'action': ['python3', '<(angle_post_build_script)', 'run', '<(angle_path)', '<(CONFIGURATION_NAME)', '$(PlatformName)', '<(PRODUCT_DIR)'],
                         },
                     ], #actions
                 },


### PR DESCRIPTION
Linux and macOS pass on Python 3 plus Node.js v16, v18, and v20 but Windows does not.
# Test results: https://github.com/cclauss/angle/actions
https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs 

@mikolalysenko Your review, please.